### PR TITLE
Bump hugo version; hugo_site correctly exposes outputs

### DIFF
--- a/hugo/internal/hugo_repository.bzl
+++ b/hugo/internal/hugo_repository.bzl
@@ -37,7 +37,7 @@ hugo_repository = repository_rule(
     _hugo_repository_impl,
     attrs = {
         "version": attr.string(
-            default = "0.127.0",
+            default = "0.139.5",
             doc = "The hugo version to use",
         ),
         "sha256": attr.string(

--- a/hugo/internal/hugo_repository.bzl
+++ b/hugo/internal/hugo_repository.bzl
@@ -37,7 +37,7 @@ hugo_repository = repository_rule(
     _hugo_repository_impl,
     attrs = {
         "version": attr.string(
-            default = "0.55.5",
+            default = "0.127.0",
             doc = "The hugo version to use",
         ),
         "sha256": attr.string(

--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -38,15 +38,8 @@ def copy_to_dir(ctx, srcs, dirname):
             outs.append(i)
     return outs
 
-def _hugo_site_impl(ctx):
-    hugo = ctx.executable.hugo
+def _hugo_inputs(ctx):
     hugo_inputs = []
-    hugo_outputdir = ctx.actions.declare_directory(ctx.label.name)
-    hugo_outputs = [hugo_outputdir]
-    hugo_args = []
-
-    if ctx.file.config == None and (ctx.files.config_dir == None or len(ctx.files.config_dir) == 0):
-        fail("You must provide either a config file or a config_dir")
 
     # Copy the config file into place
     config_dir = ctx.files.config_dir
@@ -84,7 +77,6 @@ def _hugo_site_impl(ctx):
     # Copy the theme
     if ctx.attr.theme:
         theme = ctx.attr.theme.hugo_theme
-        hugo_args += ["--theme", theme.name]
         for i in theme.files.to_list():
             path_list = i.short_path.split("/")
             if i.short_path.startswith("../"):
@@ -103,6 +95,16 @@ def _hugo_site_impl(ctx):
             )
             hugo_inputs.append(o)
 
+    return hugo_inputs
+
+def _hugo_args(ctx, hugo_outputdir):
+    hugo_args = []
+
+    # Copy the theme
+    if ctx.attr.theme:
+        theme = ctx.attr.theme.hugo_theme
+        hugo_args += ["--theme", theme.name]
+
     # Prepare hugo command
     hugo_args += [
         "--destination",
@@ -118,6 +120,19 @@ def _hugo_site_impl(ctx):
         hugo_args += ["--baseURL", ctx.attr.base_url]
     if ctx.attr.build_drafts:
         hugo_args += ["--buildDrafts"]
+
+    return hugo_args
+
+def _hugo_site_impl(ctx):
+    if ctx.file.config == None and (ctx.files.config_dir == None or len(ctx.files.config_dir) == 0):
+        fail("You must provide either a config file or a config_dir")
+
+    hugo_outputdir = ctx.actions.declare_directory(ctx.label.name)
+    hugo_outputs = [hugo_outputdir]
+    hugo = ctx.executable.hugo
+
+    hugo_inputs = _hugo_inputs(ctx)
+    hugo_args = _hugo_args(ctx, hugo_outputdir)
 
     ctx.actions.run(
         mnemonic = "GoHugo",

--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -233,7 +233,7 @@ function exit_gracefully() {
 }
 
 """
-_SERVE_SCRIPT_TEMPLATE = """{hugo_bin} serve -s $DIR {args}"""
+_SERVE_SCRIPT_TEMPLATE = """{hugo_bin} server -s $DIR {args}"""
 
 def _hugo_serve_impl(ctx):
     """ This is a long running process used for development"""
@@ -248,8 +248,6 @@ def _hugo_serve_impl(ctx):
         hugo_args.append("--verbose")
     if ctx.attr.disable_fast_render:
         hugo_args.append("--disableFastRender")
-
-    hugo_args.append("server")
 
     executable_path = "./" + ctx.attr.hugo.files_to_run.executable.short_path
 

--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -62,19 +62,20 @@ def _hugo_site_impl(ctx):
         )
 
         hugo_inputs.append(config_file)
-
+        source_dir = config_file.dirname
         hugo_args += [
-            "--source",
-            config_file.dirname,
+            "--config", config_file.basename,
         ]
     else:
         placeholder_file = ctx.actions.declare_file(".placeholder")
-        ctx.actions.write(placeholder_file, "paceholder", is_executable=False)
+        ctx.actions.write(placeholder_file, "placeholder", is_executable=False)
         hugo_inputs.append(placeholder_file)
         #  placeholder_file.dirname + "/config/_default/config.yaml",
-        hugo_args += [
-            "--source", placeholder_file.dirname
-        ]
+        source_dir = placeholder_file.dirname
+
+    hugo_args += [
+        "--source", source_dir,
+    ]
 
     # Copy all the files over
     for name, srcs in {

--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -121,7 +121,8 @@ def _hugo_site_impl(ctx):
     if ctx.attr.quiet:
         hugo_args.append("--quiet")
     if ctx.attr.verbose:
-        hugo_args.append("--verbose")
+        hugo_args.append("--logLevel")
+        hugo_args.append("info")
     if ctx.attr.base_url:
         hugo_args += ["--baseURL", ctx.attr.base_url]
     if ctx.attr.build_drafts:

--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -62,20 +62,10 @@ def _hugo_site_impl(ctx):
         )
 
         hugo_inputs.append(config_file)
-        source_dir = config_file.dirname
-        hugo_args += [
-            "--config", config_file.basename,
-        ]
     else:
         placeholder_file = ctx.actions.declare_file(".placeholder")
         ctx.actions.write(placeholder_file, "placeholder", is_executable=False)
         hugo_inputs.append(placeholder_file)
-        #  placeholder_file.dirname + "/config/_default/config.yaml",
-        source_dir = placeholder_file.dirname
-
-    hugo_args += [
-        "--source", source_dir,
-    ]
 
     # Copy all the files over
     for name, srcs in {
@@ -116,7 +106,7 @@ def _hugo_site_impl(ctx):
     # Prepare hugo command
     hugo_args += [
         "--destination",
-        ctx.label.name,
+        hugo_outputdir.path,
     ]
 
     if ctx.attr.quiet:

--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -249,6 +249,8 @@ def _hugo_serve_impl(ctx):
     if ctx.attr.disable_fast_render:
         hugo_args.append("--disableFastRender")
 
+    hugo_args.append("server")
+
     executable_path = "./" + ctx.attr.hugo.files_to_run.executable.short_path
 
     runfiles = ctx.runfiles()

--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -245,7 +245,8 @@ def _hugo_serve_impl(ctx):
     if ctx.attr.quiet:
         hugo_args.append("--quiet")
     if ctx.attr.verbose:
-        hugo_args.append("--verbose")
+        hugo_args.append("--logLevel")
+        hugo_args.append("info")
     if ctx.attr.disable_fast_render:
         hugo_args.append("--disableFastRender")
 


### PR DESCRIPTION
- **Append server argument**
- **Ooh, actually, fix the actual command**
- **Swap to non-deprecated flag**
- **Swap another deprecated flag**
- **Upgrade default Hugo version**
- **Correct typo, bump to 0.139.5**
- **Point to right output dir, and don't pass source path**
- **Pull hugo_inputs, hugo_args into separate methods**
