### PR TITLE
Support running from non-root package

### DIFF
--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -105,12 +105,20 @@ def _hugo_args(ctx, hugo_outputdir):
         theme = ctx.attr.theme.hugo_theme
         hugo_args += ["--theme", theme.name]
 
+    # Prepare the --destination argument.
+    # By default, this comes in as a path relative to the execroot.
+    # Hugo (incorrectly) nests this under the directory we pass under --source;
+    # we don't want this, so we adjust what we pass to exit from the source dir.
+    subdirs = len(ctx.label.package.split("/"))
+    destination_path = "/".join([".."] * subdirs + [hugo_outputdir.path])
+
     # Prepare hugo command
     hugo_args += [
+        # Point Hugo to the right subdirectory containing the site sources.
         "--source",
         ctx.label.package,
         "--destination",
-        hugo_outputdir.path,
+        destination_path,
         # Hugo wants to modify the static input files for its own bookkeeping
         # but of course Bazel does not want input files to be changed. This breaks
         # in some sandboxes like RBE

--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -109,6 +109,8 @@ def _hugo_args(ctx, hugo_outputdir):
     hugo_args += [
         "--destination",
         hugo_outputdir.path,
+        "--source",
+        ctx.label.package,
         # Hugo wants to modify the static input files for its own bookkeeping
         # but of course Bazel does not want input files to be changed. This breaks
         # in some sandboxes like RBE

--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -107,10 +107,10 @@ def _hugo_args(ctx, hugo_outputdir):
 
     # Prepare hugo command
     hugo_args += [
-        "--destination",
-        hugo_outputdir.path,
         "--source",
         ctx.label.package,
+        "--destination",
+        hugo_outputdir.path,
         # Hugo wants to modify the static input files for its own bookkeeping
         # but of course Bazel does not want input files to be changed. This breaks
         # in some sandboxes like RBE


### PR DESCRIPTION
By default, `rules_hugo` doesn't work well when your blog lives at a non-root directory. This adds support for that, by passing the package path under `--sources`, and then carefully backing out of that path in `--destination` to ensure that the built files end up in the right place.